### PR TITLE
limit msg's redelivery count

### DIFF
--- a/client.go
+++ b/client.go
@@ -435,32 +435,6 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// DiscardOnCount gets msg and count. Check msg's x-delivery-count from headers.
-// Compare count and x-delivery-count to decide whether redeliver or discard.
-// https://www.rabbitmq.com/quorum-queues.html#poison-message-handling
-func (c *Client) DiscardOnCount(msg amqp.Delivery, count int64) error {
-	// discard
-	if count == 0 {
-		return msg.Ack(false)
-	}
-	val, ok := msg.Headers["x-delivery-count"]
-	// x-delivery-count not exist, requeue
-	if !ok {
-		return msg.Nack(false, true)
-	}
-	intVal, ok := val.(int64)
-	// x-delivery-count is not type int, discard
-	if !ok {
-		return msg.Ack(false)
-	}
-	// if redelivered count exceeds allow count, discard
-	if intVal >= count {
-		return msg.Ack(false)
-	}
-	// else requeue msg
-	return msg.Nack(false, true)
-}
-
 func (c *Client) setConnection(connection *amqp.Connection) {
 	c.connection = connection
 

--- a/config.go
+++ b/config.go
@@ -224,14 +224,20 @@ const (
 	// QueueTypeArgument is the key used in the queue optional arguments to specify
 	// the queue type.
 	QueueTypeArgument = "x-queue-type"
-	// QueueRedeliveryLimit is queue optional arguments to limit
+	// QueueDeliveryLimit is queue optional arguments to limit
 	// redelivery count('x-delivery-count') of unacked message
 	// https://www.rabbitmq.com/quorum-queues.html#configuration
-	QueueRedeliveryLimit = "x-delivery-limit"
+	QueueDeliveryLimit = "x-delivery-limit"
 )
 
 const (
 	// QuorumQueueType is the value used with the key "x-queue-type" in the optional
 	// arguments when declaring a queue to declare a Quorum queue.
 	QuorumQueueType = "quorum"
+)
+
+const (
+	// MessageDeliveryCount in message's header represent how many times
+	// the message was redelivered.
+	MessageDeliveryCount = "x-delivery-count"
 )

--- a/queue_option.go
+++ b/queue_option.go
@@ -85,9 +85,9 @@ func WithQueueQuorum() QueueOption {
 	return WithQueueArgument(QueueTypeArgument, QuorumQueueType)
 }
 
-// WithRedeliveryLimit sets the redelivery-count's limit
+// WithDeliveryLimit sets the redelivery-count's limit
 // msg's actual consume count is always 1 greater than redelivery limit
 // because the first consumption is not counted as redelivery-count
-func WithRedeliveryLimit(limit int64) QueueOption {
-	return WithQueueArgument(QueueRedeliveryLimit, limit)
+func WithDeliveryLimit(limit int64) QueueOption {
+	return WithQueueArgument(QueueDeliveryLimit, limit)
 }


### PR DESCRIPTION
msg 가 정상적으로 처리되지 않은 경우에 큐에 다시 넣게 되는데 기존에는 무한정 넣는 문제가 있었습니다.

1. queue arguments 로 redelivery-limit 를 설정할 수 있습니다.
2. queue arguments 는 queue redeclare 할 때 적용되기 때문에 사용하고 있는 queue를 지울 수 없는 경우 적절한 버저닝 방법을 고민해야 합니다. 
3. queue arguments 를 바꾸기 전에는 컨슈머 코드 레벨에서 DiscardOnCount() 함수를 이용할 수 있습니다.
