### PR TITLE
Removed connection timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,12 +27,6 @@ var (
 	ErrEmptyQueueName = errors.New("queue name should contain at least 1 character")
 )
 
-var (
-	// errConnectionTimeout is returned when the client did not succeed to connect to the server after the
-	// configured connection timeout duration.
-	errConnectionTimeout = errors.New("connection timeout")
-)
-
 // Client is a reliable wrapper around an AMQP connection which automatically recover
 // from connection errors.
 type Client struct {
@@ -119,7 +113,6 @@ func (c *Client) Connect(ctx context.Context) error {
 }
 
 func (c *Client) handleConnection(ctx context.Context) error {
-	timeout := time.After(c.config.ConnectionConfig.Timeout)
 	for {
 		c.logger.Info("Attempting to connect to the server...")
 
@@ -127,8 +120,6 @@ func (c *Client) handleConnection(ctx context.Context) error {
 		if err != nil {
 			c.logger.Error("Connection attempt failed", err)
 			select {
-			case <-timeout:
-				return errConnectionTimeout
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-time.After(c.config.ConnectionConfig.RetryDelay):
@@ -143,8 +134,6 @@ func (c *Client) handleConnection(ctx context.Context) error {
 		}
 
 		c.isReady.Store(false)
-
-		timeout = time.After(c.config.ConnectionConfig.Timeout)
 	}
 }
 

--- a/client_option.go
+++ b/client_option.go
@@ -64,13 +64,6 @@ func WithVirtualHost(vhost string) ClientOption {
 	}
 }
 
-// WithConnectionTimeout configures the time the client will wait until a succesful connection.
-func WithConnectionTimeout(timeout time.Duration) ClientOption {
-	return func(cc *ClientConfig) {
-		cc.ConnectionConfig.Timeout = timeout
-	}
-}
-
 // WithConnectionRetryDelay configures the delay used by the client between each connection retry.
 func WithConnectionRetryDelay(delay time.Duration) ClientOption {
 	return func(cc *ClientConfig) {

--- a/config.go
+++ b/config.go
@@ -24,12 +24,9 @@ type ConnectionConfig struct {
 	Port        string
 	VirtualHost string
 	RetryDelay  time.Duration
-	Timeout     time.Duration
 }
 
 const (
-	// DefaultConnectionTimeout is the default duration the client will wait until a successful connection.
-	DefaultConnectionTimeout = time.Minute * 1
 	// DefaultConnectionRetryDelay is the default delay between each connection attempt.
 	DefaultConnectionRetryDelay = time.Second * 5
 )
@@ -43,7 +40,6 @@ var DefaultConnectionConfig = ConnectionConfig{
 	Port:        "5672",
 	VirtualHost: "",
 	RetryDelay:  DefaultConnectionRetryDelay,
-	Timeout:     DefaultConnectionTimeout,
 }
 
 // ChannelConfig contains all the configurable parameters used by a client instance


### PR DESCRIPTION
We encountered a problem where the consumers keep trying to reconnect while the connection handler stopped retrying. Therefore it makes more sense to just remove the timeout since the client should never stop.